### PR TITLE
do listener disable differently

### DIFF
--- a/lib/xayn_card_view/card_view.dart
+++ b/lib/xayn_card_view/card_view.dart
@@ -253,12 +253,14 @@ class _CardViewState extends CardViewAnimatedState with CardViewListenersMixin {
           ),
         );
 
-        return Listener(
-          onPointerDown: onDragStart(constraints),
-          onPointerMove: onDragUpdate(constraints),
-          onPointerUp: onDragEnd(constraints),
-          child: scrollable,
-        );
+        return widget.disableGestures
+            ? scrollable
+            : Listener(
+                onPointerDown: onDragStart(constraints),
+                onPointerMove: onDragUpdate(constraints),
+                onPointerUp: onDragEnd(constraints),
+                child: scrollable,
+              );
       };
 
   void _updateScrollPosition() {

--- a/lib/xayn_card_view/card_view_listeners_mixin.dart
+++ b/lib/xayn_card_view/card_view_listeners_mixin.dart
@@ -23,16 +23,12 @@ mixin CardViewListenersMixin on CardViewAnimatedState {
   @protected
   void Function(PointerDownEvent?) onDragStart(BoxConstraints constraints) =>
       (PointerDownEvent? event) {
-        if (widget.disableGestures) return;
-
         _confirmDragging(constraints);
       };
 
   @protected
   void Function(PointerMoveEvent?) onDragUpdate(BoxConstraints constraints) =>
       (PointerMoveEvent? event) {
-        if (widget.disableGestures) return;
-
         if (!_didStartDragging) {
           _confirmDragging(constraints);
         }
@@ -41,8 +37,6 @@ mixin CardViewListenersMixin on CardViewAnimatedState {
   @protected
   void Function(PointerUpEvent?) onDragEnd(BoxConstraints constraints) =>
       (PointerUpEvent? event) async {
-        if (widget.disableGestures) return;
-
         _isDragActive = false;
 
         final fullSize =


### PR DESCRIPTION
### What 🕵️ 🔍

- Fix disableGesture
- Don't keep the listener open, while the above property is true, rather don't use a Listener wrapper at all, as drag events might leak

----------

### How to test 🥼 🔬

- Swipe fast diagonally to close
- Expect the card index to not change

----------